### PR TITLE
Titlebar default color in Cyberpunk theme improvement

### DIFF
--- a/themes/cyberpunk-color-theme.json
+++ b/themes/cyberpunk-color-theme.json
@@ -147,6 +147,7 @@
 		"sideBar.border": "#1D1833",
 		"sideBar.foreground": "#b08bff",
 		"sideBarTitle.foreground": "#bbbbbb",
+		"titleBar.activeBackground": "#1D1833",
 		"widget.shadow": "#0000006b",
 	},
 	"tokenColors": [


### PR DESCRIPTION
Hi, thanks for the theme!
Default cyberpunk make use of default macOS titlebar color, so I have put color for it to match with siderbar.
Result: https://imgur.com/a/J2tI2RN
What do you think?
Cheers!