### PR TITLE
Fix active tab modified border

### DIFF
--- a/themes/cyberpunk-color-theme.json
+++ b/themes/cyberpunk-color-theme.json
@@ -146,6 +146,7 @@
 		"tab.activeBackground": "#261D45",
 		"tab.hoverBorder": "#721bf2",
 		"tab.hoverBackground": "#3f2c70",
+		"tab.activeModifiedBorder": "#00FF9C",
 
 		// Input Section
 		"input.background": "#002212ec",

--- a/themes/cyberpunk-color-theme.json
+++ b/themes/cyberpunk-color-theme.json
@@ -147,6 +147,13 @@
 		"tab.hoverBorder": "#721bf2",
 		"tab.hoverBackground": "#3f2c70",
 
+		// Menu Section
+		"menu.border": "#00FF9C",
+		"menu.background": "#002212ec",
+		"menu.foreground": "#00FF9C",
+		"menu.selectionBackground": "#00FF9C",
+		"menu.selectionForeground": "#000",
+
 		// Input Section
 		"input.background": "#002212ec",
 		"input.border": "#00FF9C",

--- a/themes/cyberpunk-scarlet-color-theme.json
+++ b/themes/cyberpunk-scarlet-color-theme.json
@@ -103,6 +103,7 @@
         "tab.border": "#101116",
         "tab.activeForeground": "#ff0055",
         "tab.inactiveForeground": "#eb4d81de",
+		"tab.activeModifiedBorder": "#00FF9C",
 		"input.background": "#001420",
 		"input.border": "#00a2ff",
 		"input.foreground": "#00ffc8",

--- a/themes/cyberpunk-scarlet-color-theme.json
+++ b/themes/cyberpunk-scarlet-color-theme.json
@@ -103,6 +103,14 @@
         "tab.border": "#101116",
         "tab.activeForeground": "#ff0055",
         "tab.inactiveForeground": "#eb4d81de",
+
+		// Menu Section
+		"menu.border": "#ff0055",
+		"menu.background": "#140007f8",
+		"menu.foreground": "#ff0055",
+		"menu.selectionBackground": "#ff0055",
+		"menu.selectionForeground": "#000",
+
 		"input.background": "#001420",
 		"input.border": "#00a2ff",
 		"input.foreground": "#00ffc8",

--- a/themes/cyberpunk-umbra-color-theme.json
+++ b/themes/cyberpunk-umbra-color-theme.json
@@ -87,6 +87,7 @@
 		"tab.inactiveBackground": "#1e1d45",
 		"tab.inactiveForeground": "#7877b3",
 		"tab.activeBackground": "#100d23",
+		"tab.activeModifiedBorder": "#00FF9C",
 		"input.background": "#002212ec",
 		"input.border": "#00FF9C",
         "input.foreground": "#00ff6a",

--- a/themes/cyberpunk-umbra-color-theme.json
+++ b/themes/cyberpunk-umbra-color-theme.json
@@ -87,6 +87,14 @@
 		"tab.inactiveBackground": "#1e1d45",
 		"tab.inactiveForeground": "#7877b3",
 		"tab.activeBackground": "#100d23",
+		
+		// Menu Section
+		"menu.border": "#00FF9C",
+		"menu.background": "#002212ec",
+		"menu.foreground": "#00FF9C",
+		"menu.selectionBackground": "#00FF9C",
+		"menu.selectionForeground": "#000",
+
 		"input.background": "#002212ec",
 		"input.border": "#00FF9C",
         "input.foreground": "#00ff6a",


### PR DESCRIPTION
Used the foreground color of the active tab.
I used the same green color for Scarlet as the red one wasn't really visible.

Fixes #76 