### PR TITLE
Add colors for inlay hints

### DIFF
--- a/themes/cyberpunk-color-theme.json
+++ b/themes/cyberpunk-color-theme.json
@@ -138,6 +138,10 @@
 		// EditorLink Section
 		"editorLink.activeForeground": "#3d81fe",
 
+		// Inlay Hints Section
+		"editorInlayHint.background": "#100D2380",
+		"editorInlayHint.foreground": "#d57bff",
+
 		// Tab Section
 		"tab.activeForeground": "#00FF9C",
 		"tab.border": "#372963",

--- a/themes/cyberpunk-scarlet-color-theme.json
+++ b/themes/cyberpunk-scarlet-color-theme.json
@@ -127,6 +127,10 @@
 		"statusBar.debuggingForeground": "#c566fc",
 		"statusBar.debuggingBorder": "#b700ff",
 
+		// Inlay Hints Section
+		"editorInlayHint.background": "#030202",
+		"editorInlayHint.foreground": "#d57bff",
+
 		// List Section
 		"list.activeSelectionBackground": "#ff005528",
 		"list.activeSelectionForeground": "#ff0055",

--- a/themes/cyberpunk-umbra-color-theme.json
+++ b/themes/cyberpunk-umbra-color-theme.json
@@ -82,6 +82,11 @@
         "editorBracketMatch.border": "#ff004c",
         "editorBracketMatch.background": "#ff005533",
         "editorWidget.border": "#00FF9C",
+
+		// Inlay Hints Section
+		"editorInlayHint.background": "#006eff2d",
+		"editorInlayHint.foreground": "#d57bff",
+
 		"tab.activeForeground": "#00FF9C",
 		"tab.border": "#372963",
 		"tab.inactiveBackground": "#1e1d45",


### PR DESCRIPTION
Used the pink keyword color for the foreground and the editor.lineHighlightBackground for the backgrounds on each theme.

Fixes #107