### PR TITLE
Fixed menu focus and added border

### DIFF
--- a/themes/cyberpunk-color-theme.json
+++ b/themes/cyberpunk-color-theme.json
@@ -147,6 +147,13 @@
 		"tab.hoverBorder": "#721bf2",
 		"tab.hoverBackground": "#3f2c70",
 
+		// Menu Section
+		"menu.border": "#00FF9C",
+		"menu.background": "#002212ec",
+		"menu.foreground": "#00FF9C",
+		"menu.selectionBackground": "#00FF9C",
+		"menu.selectionForeground": "#000",
+
 		// Input Section
 		"input.background": "#002212ec",
 		"input.border": "#00FF9C",

--- a/themes/cyberpunk-scarlet-color-theme.json
+++ b/themes/cyberpunk-scarlet-color-theme.json
@@ -103,6 +103,14 @@
         "tab.border": "#101116",
         "tab.activeForeground": "#ff0055",
         "tab.inactiveForeground": "#eb4d81de",
+
+		// Menu Section
+		"menu.border": "#ff0055",
+		"menu.background": "#140007f8",
+		"menu.foreground": "#ff0055",
+		"menu.selectionBackground": "#ff0055",
+		"menu.selectionForeground": "#000",
+
 		"input.background": "#001420",
 		"input.border": "#00a2ff",
 		"input.foreground": "#00ffc8",

--- a/themes/cyberpunk-umbra-color-theme.json
+++ b/themes/cyberpunk-umbra-color-theme.json
@@ -87,6 +87,14 @@
 		"tab.inactiveBackground": "#1e1d45",
 		"tab.inactiveForeground": "#7877b3",
 		"tab.activeBackground": "#100d23",
+		
+		// Menu Section
+		"menu.border": "#00FF9C",
+		"menu.background": "#002212ec",
+		"menu.foreground": "#00FF9C",
+		"menu.selectionBackground": "#00FF9C",
+		"menu.selectionForeground": "#000",
+
 		"input.background": "#002212ec",
 		"input.border": "#00FF9C",
         "input.foreground": "#00ff6a",


### PR DESCRIPTION
Added missing colors to the menu, including a border to match other items like the dropdowns and suggestion widgets.

border = editorSuggestWidget.border
background = editorSuggestWidget.background
foreground = editorSuggestWidget.foreground
selection background = editorSuggestWidget.foreground
selection foreground = black (for max contrast)

Fixes #106 

<img width="705" alt="Code_GSul4loA0B" src="https://user-images.githubusercontent.com/48868528/164954431-96581586-6c88-4675-ae23-0da8894de07c.png">


